### PR TITLE
Hooks to allow corona-admin users to specify a transformer to run on document inserts and/or fetches

### DIFF
--- a/config/endpoints.xqy
+++ b/config/endpoints.xqy
@@ -275,6 +275,13 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
         </http>
     </request>
 
+    <request uri="^/manage/(namedqueryprefixes|namedqueryprefix/([^/]+))/?$" endpoint="/corona/manage/namedqueryprefix.xqy" user-params="allow">
+        <uri-param name="prefix" as="string">$2</uri-param>
+        <http method="GET"/>
+        <http method="POST"/>
+        <http method="DELETE"/>
+    </request>
+
     <request uri="^/manage/hooks/?$" endpoint="/corona/manage/hooks.xqy" user-params="allow">
         <http method="GET"/>
         <http method="POST">
@@ -283,15 +290,13 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
 	    </http>
     </request>
 
-    <request uri="^/manage/(namedqueryprefixes|namedqueryprefix/([^/]+))/?$" endpoint="/corona/manage/namedqueryprefix.xqy" user-params="allow">
-        <uri-param name="prefix" as="string">$2</uri-param>
+    <request uri="^/config/setup/?$" endpoint="/config/setup.xqy" user-params="allow">
         <http method="GET"/>
         <http method="POST"/>
-        <http method="DELETE"/>
     </request>
-declare function endpoints:options(
-) as element(rest:options)
-{
+
+</options>;
+
 declare function endpoints:options(
 ) as element(rest:options)
 {

--- a/config/endpoints.xqy
+++ b/config/endpoints.xqy
@@ -75,7 +75,7 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
     </request>
 
     <!-- Search endpoint -->
-    <request uri="^/search(/)?$" endpoint="/corona/search.xqy" user-params="allow">
+    <request uri="^/search/?$" endpoint="/corona/search.xqy" user-params="allow">
         <param name="txid" required="false"/>
         <param name="stringQuery" required="false"/>
         <param name="structuredQuery" required="false"/>
@@ -94,7 +94,7 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
     </request>
 
     <!-- Key value queryies -->
-    <request uri="^/kvquery$" endpoint="/corona/kvquery.xqy" user-params="allow">
+    <request uri="^/kvquery/?$" endpoint="/corona/kvquery.xqy" user-params="allow">
         <param name="txid" required="false"/>
         <param name="key" required="false"/>
         <param name="element" required="false"/>
@@ -171,12 +171,12 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
 
     <!-- Index management -->
 
-    <request uri="^/manage(/)?$" endpoint="/corona/manage/summary.xqy" user-params="allow">
+    <request uri="^/manage/?$" endpoint="/corona/manage/summary.xqy" user-params="allow">
         <http method="GET"/>
         <http method="DELETE"/>
     </request>
 
-    <request uri="^/manage(/)?$" endpoint="/corona/manage/state.xqy" user-params="allow">
+    <request uri="^/manage/?$" endpoint="/corona/manage/state.xqy" user-params="allow">
         <http method="POST">
             <param name="isManaged" as="boolean" required="false"/>
             <param name="insertTransforms" as="boolean" required="false"/>
@@ -285,7 +285,7 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
 	    </http>
     </request>
 
-    <request uri="^/config/setup" endpoint="/config/setup.xqy" user-params="allow">
+    <request uri="^/config/setup/?$" endpoint="/config/setup.xqy" user-params="allow">
         <http method="GET"/>
         <http method="POST"/>
     </request>

--- a/config/endpoints.xqy
+++ b/config/endpoints.xqy
@@ -179,6 +179,8 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
     <request uri="^/manage(/)?$" endpoint="/corona/manage/state.xqy" user-params="allow">
         <http method="POST">
             <param name="isManaged" as="boolean" required="false"/>
+            <param name="insertTransforms" as="boolean" required="false"/>
+            <param name="fetchTransforms" as="boolean" required="false"/>
         </http>
     </request>
 
@@ -273,6 +275,14 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
             <param name="place" required="false"/>
             <param name="type" required="false" default="include"/>
         </http>
+    </request>
+
+    <request uri="^/manage/hooks/?$" endpoint="/corona/manage/hooks.xqy" user-params="allow">
+        <http method="GET"/>
+        <http method="POST">
+            <param name="setInsertTransform" required="false"/>
+            <param name="setFetchTransform" required="false"/>
+	    </http>
     </request>
 
     <request uri="^/config/setup" endpoint="/config/setup.xqy" user-params="allow">

--- a/corona/lib/error-handler.xqy
+++ b/corona/lib/error-handler.xqy
@@ -20,4 +20,4 @@ import module namespace common="http://marklogic.com/corona/common" at "../lib/c
 
 declare variable $error:errors as node()* external;
 
-common:errorFromException($error:errors, xdmp:get-request-field("outputFormat"))
+common:output(common:errorFromException($error:errors[1], xdmp:get-request-field("outputFormat")))

--- a/corona/lib/manage.xqy
+++ b/corona/lib/manage.xqy
@@ -68,6 +68,37 @@ declare function manage:fetchTransformsEnabled(
     (prop:get("fetchTransforms"), true())[1]
 };
 
+
+declare function manage:setInsertTransform(
+    $insertTransformer as xs:string
+) as empty-sequence()
+{
+	if(string-length($insertTransformer))
+	then prop:set("insertTransformer", $insertTransformer, true())
+	else prop:delete("insertTransformer")
+};
+
+declare function manage:getInsertTransformer(
+) as xs:string?
+{
+	prop:get("insertTransformer")
+};
+
+declare function manage:setFetchTransform(
+    $fetchTransformer as xs:string
+) as empty-sequence()
+{
+	if(string-length($fetchTransformer))
+	then prop:set("fetchTransformer", $fetchTransformer, true())
+	else prop:delete("fetchTransformer")
+};
+
+declare function manage:getFetchTransformer(
+) as xs:string?
+{
+	prop:get("fetchTransformer")
+};
+
 (: Ranges :)
 declare function manage:createJSONRange(
     $name as xs:string,

--- a/corona/lib/store.xqy
+++ b/corona/lib/store.xqy
@@ -96,7 +96,9 @@ declare function store:outputDocument(
 
     (: Apply the transformation :)
     let $content :=
-        if(exists($applyTransform) and manage:fetchTransformsEnabled())
+		if(exists(manage:getFetchTransformer()))
+		then store:applyTransformer(manage:getFetchTransformer(), $content)
+        else if(exists($applyTransform) and manage:fetchTransformsEnabled())
         then store:applyTransformer($applyTransform, $content)
         else $content
 
@@ -417,7 +419,9 @@ declare function store:insertDocument(
 
     (: Apply the transformation :)
     let $body :=
-        if(exists($applyTransform) and manage:insertTransformsEnabled())
+		if(exists(manage:getFetchTransformer()))
+		then store:applyTransformer(manage:getFetchTransformer(), $body)
+        else if(exists($applyTransform) and manage:insertTransformsEnabled())
         then store:applyTransformer($applyTransform, $body)
         else $body
 
@@ -509,7 +513,9 @@ declare function store:updateDocumentContent(
 
     (: Apply the transformation :)
     let $body :=
-        if(exists($applyTransform) and manage:insertTransformsEnabled())
+		if(exists(manage:getFetchTransformer()))
+		then store:applyTransformer(manage:getFetchTransformer(), $body)
+        else if(exists($applyTransform) and manage:insertTransformsEnabled())
         then store:applyTransformer($applyTransform, $body)
         else $body
 
@@ -923,7 +929,9 @@ declare private function store:createSidecarDocument(
                         }</corona:extractedContent>
 
                     return
-                        if(exists($applyTransform) and manage:insertTransformsEnabled())
+						if(exists(manage:getFetchTransformer()))
+						then store:applyTransformer(manage:getFetchTransformer(), $content)
+                        else if(exists($applyTransform) and manage:insertTransformsEnabled())
                         then store:applyTransformer($applyTransform, $content)
                         else $content
                 else ()

--- a/corona/lib/store.xqy
+++ b/corona/lib/store.xqy
@@ -54,6 +54,11 @@ declare function store:outputRawDocument(
 
     (: Apply the transformation :)
     let $content :=
+		if(exists(manage:getFetchTransformer()))
+		then store:applyTransformer(manage:getFetchTransformer(), $content)
+		else $content
+
+    let $content :=
         if(exists($applyTransform) and manage:fetchTransformsEnabled())
         then store:applyTransformer($applyTransform, $content)
         else $content
@@ -124,7 +129,10 @@ declare function store:outputDocument(
     let $content :=
 		if(exists(manage:getFetchTransformer()))
 		then store:applyTransformer(manage:getFetchTransformer(), $content)
-        else if(exists($applyTransform) and manage:fetchTransformsEnabled())
+		else $content
+
+    let $content :=
+        if(exists($applyTransform) and manage:fetchTransformsEnabled())
         then store:applyTransformer($applyTransform, $content)
         else $content
 
@@ -447,7 +455,10 @@ declare function store:insertDocument(
     let $body :=
 		if(exists(manage:getInsertTransformer()))
 		then store:applyTransformer(manage:getInsertTransformer(), $body)
-        else if(exists($applyTransform) and manage:insertTransformsEnabled())
+		else $body
+
+    let $body :=
+        if(exists($applyTransform) and manage:insertTransformsEnabled())
         then store:applyTransformer($applyTransform, $body)
         else $body
 
@@ -541,7 +552,10 @@ declare function store:updateDocumentContent(
     let $body :=
 		if(exists(manage:getInsertTransformer()))
 		then store:applyTransformer(manage:getInsertTransformer(), $body)
-        else if(exists($applyTransform) and manage:insertTransformsEnabled())
+		else $body
+
+	let $body :=
+        if(exists($applyTransform) and manage:insertTransformsEnabled())
         then store:applyTransformer($applyTransform, $body)
         else $body
 
@@ -988,12 +1002,17 @@ declare private function store:createSidecarDocument(
                             return <corona:extractedPara>{ $string }</corona:extractedPara>
                         }</corona:extractedContent>
 
-                    return
+					let $content :=
 						if(exists(manage:getInsertTransformer()))
 						then store:applyTransformer(manage:getInsertTransformer(), $content)
-                        else if(exists($applyTransform) and manage:insertTransformsEnabled())
+						else $content
+
+					let $content :=
+                        if(exists($applyTransform) and manage:insertTransformsEnabled())
                         then store:applyTransformer($applyTransform, $content)
                         else $content
+
+                    return $content
                 else ()
             )
         }

--- a/corona/lib/store.xqy
+++ b/corona/lib/store.xqy
@@ -419,8 +419,8 @@ declare function store:insertDocument(
 
     (: Apply the transformation :)
     let $body :=
-		if(exists(manage:getFetchTransformer()))
-		then store:applyTransformer(manage:getFetchTransformer(), $body)
+		if(exists(manage:getInsertTransformer()))
+		then store:applyTransformer(manage:getInsertTransformer(), $body)
         else if(exists($applyTransform) and manage:insertTransformsEnabled())
         then store:applyTransformer($applyTransform, $body)
         else $body
@@ -513,8 +513,8 @@ declare function store:updateDocumentContent(
 
     (: Apply the transformation :)
     let $body :=
-		if(exists(manage:getFetchTransformer()))
-		then store:applyTransformer(manage:getFetchTransformer(), $body)
+		if(exists(manage:getInsertTransformer()))
+		then store:applyTransformer(manage:getInsertTransformer(), $body)
         else if(exists($applyTransform) and manage:insertTransformsEnabled())
         then store:applyTransformer($applyTransform, $body)
         else $body
@@ -929,8 +929,8 @@ declare private function store:createSidecarDocument(
                         }</corona:extractedContent>
 
                     return
-						if(exists(manage:getFetchTransformer()))
-						then store:applyTransformer(manage:getFetchTransformer(), $content)
+						if(exists(manage:getInsertTransformer()))
+						then store:applyTransformer(manage:getInsertTransformer(), $content)
                         else if(exists($applyTransform) and manage:insertTransformsEnabled())
                         then store:applyTransformer($applyTransform, $content)
                         else $content

--- a/corona/lib/store.xqy
+++ b/corona/lib/store.xqy
@@ -453,14 +453,14 @@ declare function store:insertDocument(
 
     (: Apply the transformation :)
     let $body :=
-		if(exists(manage:getInsertTransformer()))
-		then store:applyTransformer(manage:getInsertTransformer(), $body)
-		else $body
-
-    let $body :=
         if(exists($applyTransform) and manage:insertTransformsEnabled())
         then store:applyTransformer($applyTransform, $body)
         else $body
+
+    let $body :=
+		if(exists(manage:getInsertTransformer()))
+		then store:applyTransformer(manage:getInsertTransformer(), $body)
+		else $body
 
     let $insert := xdmp:document-insert($uri, $body, (xdmp:default-permissions(), $permissions), $collections, $quality)
     let $set :=
@@ -549,15 +549,15 @@ declare function store:updateDocumentContent(
         else error(xs:QName("corona:INVALID-PARAMETER"), "Invalid content type, must be one of xml or json")
 
     (: Apply the transformation :)
-    let $body :=
-		if(exists(manage:getInsertTransformer()))
-		then store:applyTransformer(manage:getInsertTransformer(), $body)
-		else $body
-
 	let $body :=
         if(exists($applyTransform) and manage:insertTransformsEnabled())
         then store:applyTransformer($applyTransform, $body)
         else $body
+
+    let $body :=
+		if(exists(manage:getInsertTransformer()))
+		then store:applyTransformer(manage:getInsertTransformer(), $body)
+		else $body
 
     let $update :=
         if($contentType = "text")
@@ -1003,14 +1003,14 @@ declare private function store:createSidecarDocument(
                         }</corona:extractedContent>
 
 					let $content :=
-						if(exists(manage:getInsertTransformer()))
-						then store:applyTransformer(manage:getInsertTransformer(), $content)
-						else $content
-
-					let $content :=
                         if(exists($applyTransform) and manage:insertTransformsEnabled())
                         then store:applyTransformer($applyTransform, $content)
                         else $content
+
+					let $content :=
+						if(exists(manage:getInsertTransformer()))
+						then store:applyTransformer(manage:getInsertTransformer(), $content)
+						else $content
 
                     return $content
                 else ()

--- a/corona/manage/hooks.xqy
+++ b/corona/manage/hooks.xqy
@@ -1,0 +1,72 @@
+(:
+Copyright 2011 Swell Lines LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+:)
+
+xquery version "1.0-ml";
+
+import module namespace manage="http://marklogic.com/corona/manage" at "../lib/manage.xqy";
+import module namespace common="http://marklogic.com/corona/common" at "../lib/common.xqy";
+import module namespace json="http://marklogic.com/json" at "../lib/json.xqy";
+
+import module namespace rest="http://marklogic.com/appservices/rest" at "../lib/rest/rest.xqy";
+import module namespace endpoints="http://marklogic.com/corona/endpoints" at "/config/endpoints.xqy";
+
+declare option xdmp:mapping "false";
+
+
+let $params := rest:process-request(endpoints:request("/corona/manage/hooks.xqy"))
+let $requestMethod := xdmp:get-request-method()
+let $insertTransformer := map:get($params, "setInsertTransform")
+let $fetchTransformer := map:get($params, "setFetchTransform")
+
+let $transformerName :=
+	if(string-length($insertTransformer))
+	then $insertTransformer
+	else if(string-length($fetchTransformer))
+	then $fetchTransformer
+	else ()
+
+return common:output(
+    try {
+		if(exists($transformerName) and empty(manage:getTransformer($transformerName)))
+		then common:error("corona:INVALID-PARAMETER", concat("No transformer with the name: '", $transformerName, "'"), "json")
+
+		else if($requestMethod = "POST")
+		then (
+			xdmp:set-response-code(204, "Hook saved"),
+
+			if(exists($insertTransformer))
+			then manage:setInsertTransform($insertTransformer)
+			else if(exists($fetchTransformer))
+			then manage:setFetchTransform($fetchTransformer)
+			else common:error("corona:INVALID-PARAMETER", "Must specify a hook to set", "json")
+		)
+		else if($requestMethod = "GET")
+		then json:object((
+			if(exists(manage:getInsertTransformer()))
+			then ("insertTransformer", manage:getInsertTransformer())
+			else (),
+
+			if(exists(manage:getFetchTransformer()))
+			then ("fetchTransformer", manage:getFetchTransformer())
+			else ()
+		))
+		else ()
+    }
+    catch ($e) {
+        common:errorFromException($e, "json")
+    }
+)
+

--- a/test/hooks.html
+++ b/test/hooks.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>hooks tests</title>
+    <script type="text/javascript" src="js/qunit.js"></script>
+    <script type="text/javascript" src="js/jquery.js"></script>
+    <link rel="stylesheet" href="css/qunit.css" type="text/css" media="screen" />
+  </head>
+  <body>
+    <script type="text/javascript" src="js/common.js"></script>
+    <script type="text/javascript" src="js/hooks-tests.js"></script>
+    <h1 id="qunit-header">Corona hooks management unit tests</h1>
+    <h2 id="qunit-banner"></h2>
+    <div id="qunit-testrunner-toolbar"></div>
+    <h2 id="qunit-userAgent"></h2>
+    <ol id="qunit-tests"></ol>
+    <div id="qunit-fixture">test markup, will be hidden</div>
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -15,5 +15,6 @@
         <li><a href="string-query.html">String Query Endpoint</a></li>
         <li><a href="transactions.html">Transactions Endpoint</a></li>
         <li><a href="state.html">State Endpoint</a></li>
+        <li><a href="hooks.html">Hooks Endpoint</a></li>
     </ul>
 </html>

--- a/test/js/hooks-tests.js
+++ b/test/js/hooks-tests.js
@@ -1,0 +1,126 @@
+if(typeof corona == "undefined" || !corona) {
+    corona = {};
+    corona.stash = {};
+}
+
+corona.setInsertHook = function(name, callback) {
+    asyncTest("Setting insert hook to: " + name, function() {
+        $.ajax({
+            url: "/manage/hooks",
+            data: {setInsertTransform: name},
+            type: 'POST',
+            success: function() {
+                ok(true, "Insert hook set");
+				$.ajax({
+					url: "/manage/hooks",
+					type: 'GET',
+					success: function(data) {
+						ok(true, "Get hooks");
+						if(name !== "") {
+							equals(data.insertTransformer, name, "Insert transformer set to: " + name);
+						}
+						else {
+							equals(data.insertTransformer, undefined, "Insert transformer removed");
+						}
+						if(callback) {
+							callback.call(this);
+						}
+					},
+					error: function(j, t, error) {
+						ok(false, "Get hooks");
+					}
+                });
+            },
+            error: function(j, t, error) {
+                ok(false, "Insert hook set");
+            },
+			complete: function() { start(); }
+        });
+    });
+};
+
+corona.setFetchHook = function(name, callback) {
+    asyncTest("Setting fetch hook to: " + name, function() {
+        $.ajax({
+            url: "/manage/hooks",
+            data: {setFetchTransform: name},
+            type: 'POST',
+            success: function() {
+                ok(true, "Fetch hook set");
+				$.ajax({
+					url: "/manage/hooks",
+					type: 'GET',
+					success: function(data) {
+						ok(true, "Get hooks");
+						if(name !== "") {
+							equals(data.fetchTransformer, name, "Fetch transformer set to: " + name);
+						}
+						else {
+							equals(data.fetchTransformer, undefined, "Fetch transformer removed");
+						}
+						if(callback) {
+							callback.call(this);
+						}
+					},
+					error: function(j, t, error) {
+						ok(false, "Get hooks");
+					}
+                });
+            },
+            error: function(j, t, error) {
+                ok(false, "Fetch hook set");
+            },
+			complete: function() { start(); }
+        });
+    });
+};
+
+$(document).ready(function() {
+    module("Hooks Management");
+    corona.setInsertHook("adddate", function() {
+		asyncTest("Inserting document", function() {
+			$.ajax({
+				url: "/store?uri=/auto-transform.xml&respondWithContent=true",
+				data: "<foo/>",
+				type: 'PUT',
+				success: function(response) {
+					ok(true, "Inserted document with auto-transform");
+					equals(response.getElementsByTagName("wrapper").length, 1, "Transformer was applied to document");
+					corona.setInsertHook("");
+				},
+				error: function(j, t, error) {
+					ok(false, "Inserted document with auto-transform");
+				},
+				complete: function() { start(); }
+			});
+		});
+    });
+
+    corona.setFetchHook("adddate", function() {
+		asyncTest("Inserting document", function() {
+			$.ajax({
+				url: "/store?uri=/auto-transform-on-fetch.xml",
+				data: "<foo/>",
+				type: 'PUT',
+				success: function(response) {
+					$.ajax({
+						url: "/store?uri=/auto-transform-on-fetch.xml",
+						type: 'GET',
+						success: function(response) {
+							ok(true, "Fetching document with auto-transform");
+							equals(response.getElementsByTagName("wrapper").length, 1, "Transformer was applied to document");
+							corona.setFetchHook("");
+						},
+						error: function(j, t, error) {
+							ok(false, "Fetching document with auto-transform");
+						}
+					});
+				},
+				error: function(j, t, error) {
+					ok(false, "Inserted document");
+				},
+				complete: function() { start(); }
+			});
+		});
+    });
+});

--- a/test/js/hooks-tests.js
+++ b/test/js/hooks-tests.js
@@ -75,8 +75,7 @@ corona.setFetchHook = function(name, callback) {
     });
 };
 
-$(document).ready(function() {
-    module("Hooks Management");
+corona.testInsertHook = function(callback) {
     corona.setInsertHook("adddate", function() {
 		asyncTest("Inserting document", function() {
 			$.ajax({
@@ -86,7 +85,7 @@ $(document).ready(function() {
 				success: function(response) {
 					ok(true, "Inserted document with auto-transform");
 					equals(response.getElementsByTagName("wrapper").length, 1, "Transformer was applied to document");
-					corona.setInsertHook("");
+					corona.setInsertHook("", callback);
 				},
 				error: function(j, t, error) {
 					ok(false, "Inserted document with auto-transform");
@@ -95,7 +94,9 @@ $(document).ready(function() {
 			});
 		});
     });
+};
 
+corona.testFetchHook = function(callback) {
     corona.setFetchHook("adddate", function() {
 		asyncTest("Inserting document", function() {
 			$.ajax({
@@ -109,7 +110,7 @@ $(document).ready(function() {
 						success: function(response) {
 							ok(true, "Fetching document with auto-transform");
 							equals(response.getElementsByTagName("wrapper").length, 1, "Transformer was applied to document");
-							corona.setFetchHook("");
+							corona.setFetchHook("", callback);
 						},
 						error: function(j, t, error) {
 							ok(false, "Fetching document with auto-transform");
@@ -123,4 +124,11 @@ $(document).ready(function() {
 			});
 		});
     });
+};
+
+
+$(document).ready(function() {
+    module("Hooks Management");
+	corona.testInsertHook(corona.testFetchHook);
+
 });


### PR DESCRIPTION
Allows code to always be executed right before a document will be inserted and right after a document is fetched.  One use case for this is schema validation before insertion.  Could do other things like manage last-updated timestamps.  All kinds of goodies.

Tests are included.  New /manage/hooks endpoint was created.

Along the way I also fixed a couple bugs in the error handler.
