### PR TITLE
Added a repair parameter when inserting/updating documents

### DIFF
--- a/config/endpoints.xqy
+++ b/config/endpoints.xqy
@@ -51,6 +51,7 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
             <param name="extractContent" required="false" as="boolean" default="true"/>
             <param name="applyTransform" required="false"/>
             <param name="respondWithContent" required="false" as="boolean" default="false"/>
+            <param name="repair" required="false" as="boolean" default="false"/>
         </http>
         <http method="PUT">
             <param name="contentType" required="false" values="json|xml|text|binary"/>
@@ -63,6 +64,7 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
             <param name="extractContent" required="false" as="boolean" default="true"/>
             <param name="applyTransform" required="false"/>
             <param name="respondWithContent" required="false" as="boolean" default="false"/>
+            <param name="repair" required="false" as="boolean" default="false"/>
         </http>
         <http method="DELETE">
             <param name="stringQuery" required="false"/>

--- a/corona/store.xqy
+++ b/corona/store.xqy
@@ -139,7 +139,7 @@ return
             return
                 if($contentType = "binary")
                 then store:insertBinaryDocument($uri, $bodyContent, map:get($params, "contentForBinary"), $collections, $properties, $permissions, $quality, map:get($params, "extractMetadata"), map:get($params, "extractContent"), $applyTransform, $params, $respondWithContent)
-                else store:insertDocument($uri, $bodyContent, $collections, $properties, $permissions, $quality, $contentType, $applyTransform, $params, $respondWithContent)
+                else store:insertDocument($uri, $bodyContent, $collections, $properties, $permissions, $quality, $contentType, map:get($params, "repair"), $applyTransform, $params, $respondWithContent)
         }
         catch ($e) {
             common:errorFromException($e, $outputFormat)
@@ -176,12 +176,12 @@ return
                     then
                         if($contentType = "binary")
                         then store:insertBinaryDocument($uri, $bodyContent, map:get($params, "contentForBinary"), $collections, $properties, $permissions, $quality, map:get($params, "extractMetadata"), map:get($params, "extractContent"), $applyTransform, $params, $respondWithContent)
-                        else store:insertDocument($uri, $bodyContent, $collections, $properties, $permissions, $quality, $contentType, $applyTransform, $params, $respondWithContent)
+                        else store:insertDocument($uri, $bodyContent, $collections, $properties, $permissions, $quality, $contentType, map:get($params, "repair"), $applyTransform, $params, $respondWithContent)
                     else if(exists($bodyContent))
                     then
                         if($contentType = "binary")
                         then store:updateBinaryDocumentContent($uri, $bodyContent, map:get($params, "contentForBinary"), map:get($params, "extractMetadata"), map:get($params, "extractContent"), $applyTransform, $params, $respondWithContent)
-                        else store:updateDocumentContent($uri, $bodyContent, $contentType, $applyTransform, $params, $respondWithContent)
+                        else store:updateDocumentContent($uri, $bodyContent, $contentType, map:get($params, "repair"), $applyTransform, $params, $respondWithContent)
                     else (),
                     if(exists($properties))
                     then store:setProperties($uri, $properties)


### PR DESCRIPTION
When inserting or updating a document, the user can now provide a repair=true parameter to enable the auto-repairing features of MarkLogic.  Also improved the error message to show line numbers and a description of what went wrong with parsing the provided XML content.
